### PR TITLE
Create base for routing

### DIFF
--- a/gtkm/common/__init__.py
+++ b/gtkm/common/__init__.py
@@ -1,0 +1,1 @@
+from .routing import gen_url

--- a/gtkm/common/routing.py
+++ b/gtkm/common/routing.py
@@ -1,0 +1,3 @@
+def gen_url(endpoint: str) -> str:
+    '''Generates full URL from selected API endpoint'''
+    return "http://127.0.0.1:8000" + endpoint

--- a/gtkm/static/index.html
+++ b/gtkm/static/index.html
@@ -18,7 +18,7 @@
                 <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">Sign in
                 <span class="caret"></span></button>
                 <ul class="dropdown-menu">
-                  <li><a class="github-button" href="http://127.0.0.1:8000/api/auth/github/authorize" target="_blank"> <img src="images/GitHub-Mark-32px.png" alt=""> with GitHub</a></li>
+                  <li><a class="github-button" href="/api/auth/github/authorize" target="_blank"> <img src="images/GitHub-Mark-32px.png" alt=""> with GitHub</a></li>
                   <li><a class="gitlab-button"> <img src="images/gitlab-icon (1).svg"> with GitLab</a></li>
                 </ul>
               </div>
@@ -31,7 +31,7 @@
                 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad 
                 minim veniam, quis nostrud exercitation 
                 ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-                <a class="github" href="http://127.0.0.1:8000/api/auth/github/authorize" target="_blank">Sign in with GitHub </a>
+                <a class="github" href="/api/auth/github/authorize" target="_blank">Sign in with GitHub </a>
                 <p></p>
                 <a class="gitlab">Sign in with GitLab</a>
           </div>

--- a/gtkm/stats/github_fetcher.py
+++ b/gtkm/stats/github_fetcher.py
@@ -5,6 +5,7 @@ import json as JSON
 import httpx
 
 from ..stats.fetched_data_schema import BasicUserData
+from ..common import gen_url
 
 github_fetcher = APIRouter()
 
@@ -67,12 +68,12 @@ def jsons_parser(basic_user_data: str, repos_info: str):
 
 async def get_user_name(gtkm_cookie):
     if gtkm_cookie:
-        user_id = await get_endpoint_data('http://127.0.0.1:8000/auth/user/id',
+        user_id = await get_endpoint_data(gen_url('/auth/user/id'),
                                           cookie=gtkm_cookie)
 
-        user_name = await get_endpoint_data(
-            "http://127.0.0.1:8000/auth/user/?id=" + user_id.json()["id"],
-            cookie=gtkm_cookie)
+        user_name = await get_endpoint_data(gen_url("/auth/user/?id=" +
+                                                    user_id.json()["id"]),
+                                            cookie=gtkm_cookie)
 
         return user_name.json()["github_login"]
 


### PR DESCRIPTION
Od teraz nikt ma nie wpisywać ręcznie adresów przy wykonywaniu zapytań na ednpointy należące do naszej aplikacji.   
Macie do tego używać funkcji `gen_url`